### PR TITLE
fix typo in help message

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -24,7 +24,7 @@
 static int usage(char **argv) {
 	printf("\nUsage:\t%s -q -f config_file program_name [arguments]\n"
 	       "\t-q makes proxychains quiet - this overrides the config setting\n"
-	       "\t-t allows to manually specify a configfile to use\n"
+	       "\t-f allows to manually specify a configfile to use\n"
 	       "\tfor example : proxychains telnet somehost.com\n" "More help in README file\n\n", argv[0]);
 	return EXIT_FAILURE;
 }


### PR DESCRIPTION
it should be "-f" instead of "-t"

thanks!
