### PR TITLE
Fix NULL pointer deref (issue #17)

### DIFF
--- a/src/libproxychains.c
+++ b/src/libproxychains.c
@@ -168,7 +168,11 @@ static void get_chain_data(proxy_data * pd, unsigned int *proxy_count, chain_typ
 	*ct = DYNAMIC_TYPE;
 	
 	env = get_config_path(getenv(PROXYCHAINS_CONF_FILE_ENV_VAR), buff, sizeof(buff));
-	file = fopen(env, "r");
+	if( ( file = fopen(env, "r") ) == NULL )
+	{
+	        perror("couldnt read configuration file");
+        	exit(1);
+	}
 
 	env = getenv(PROXYCHAINS_QUIET_MODE_ENV_VAR);
 	if(env && *env == '1')


### PR DESCRIPTION
if a configuration file can be accessed by proxychains but there is a
mandatory access control (or other) block on the target appication's
ability to read that file, fopen() creates a NULL pointer that will
cause a segfault in fgets().

closes #17

Signed-off-by: mancha mancha1@hush.com
