### PR TITLE
Preserve old environment variable values when preloading

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -62,7 +62,7 @@ static int putenv_prepend(char* string) {
 
     char orig[256];
 
-    strncpy(orig, string, sizeof(orig));
+    strcpy(orig, string);
     value = getenv(strtok(orig, "="));
 
     if(NULL == value)


### PR DESCRIPTION
When used with nonempty LD_PRELOAD, old value will be overwritten. This can cause problems when program is executed from special environment, e.g. optirun/primusrun (bumblebee) context which sets LD_PRELOAD and program using OpenGL will fail if the correct library is not preloaded.

Tested on Linux. Need testing on Mac OS X.
