### PR TITLE
CVE-2015-3887: fix RPATH flaw

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -33,7 +33,6 @@ static const char *dll_name = DLL_NAME;
 
 static char own_dir[256];
 static const char *dll_dirs[] = {
-	".",
 	own_dir,
 	LIB_DIR,
 	"/lib",


### PR DESCRIPTION
Prevents an attacker to load a manipulated library instead of the
original .so file.