### PR TITLE
fix compile error of 'struct in6_addr' on OSX

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -28,6 +28,16 @@
 
 #include "ip_type.h"
 
+#if defined(__APPLE__) || defined(__darwin__)
+/* OSX don't define these. */
+#ifndef s6_addr16
+#define s6_addr16 __u6_addr.__u6_addr16
+#endif
+#ifndef s6_addr32
+#define s6_addr32 __u6_addr.__u6_addr32
+#endif
+#endif
+
 /*error codes*/
 typedef enum {
 	SUCCESS=0,


### PR DESCRIPTION
In /usr/include/netinet6/in6.h, in6_addr is like this:
149 /*
150  * IPv6 address
151  */
152 struct in6_addr {
153 >-union {
154 >->-__uint8_t   __u6_addr8[16];
155 >->-__uint16_t  __u6_addr16[8];
156 >->-__uint32_t  __u6_addr32[4];
157 >-} __u6_addr;>->->-/* 128-bit IP6 address */
158 };