### PR TITLE
Fix tiny misassignment in hostsreader

### DIFF
--- a/src/hostsreader.c
+++ b/src/hostsreader.c
@@ -44,7 +44,7 @@ int hostsreader_get(struct hostsreader *ctx, char* buf, size_t bufsize) {
 			l--;
 		}
 		if(!l || !*p) continue;
-		ctx->name = buf;
+		ctx->name = p;
 		while(*p && !isspace(*p) && l) {
 			p++;
 			l--;


### PR DESCRIPTION
`hostsreader_get` used to assign the IP address to both `name` and `ip`
fields in `struct hostsreader`, which led to proxychains effectively
ignoring the contents of `/etc/hosts`.