### PR TITLE
FTBFS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ GENH = src/version.h
 CFLAGS  += -Wall -O0 -g -std=c99 -D_GNU_SOURCE -pipe
 NO_AS_NEEDED = -Wl,--no-as-needed
 LIBDL   = -ldl
-LDFLAGS = -shared -fPIC $(NO_AS_NEEDED) $(LIBDL) -lpthread
+LDFLAGS = -fPIC $(NO_AS_NEEDED) $(LIBDL) -lpthread
 INC     = 
 PIC     = -fPIC
 AR      = $(CROSS_COMPILE)ar
@@ -82,7 +82,7 @@ src/version.o: src/version.h
 
 $(LDSO_PATHNAME): $(LOBJS)
 	$(CC) $(LDFLAGS) $(LD_SET_SONAME)$(LDSO_PATHNAME) $(USER_LDFLAGS) \
-		-o $@ $(LOBJS)
+		-shared -o $@ $(LOBJS)
 
 $(ALL_TOOLS): $(OBJS)
 	$(CC) src/main.o src/common.o $(USER_LDFLAGS) -o $(PXCHAINS)

--- a/src/ip_type.c
+++ b/src/ip_type.c
@@ -1,5 +1,5 @@
 #include "ip_type.h"
 
 const ip_type ip_type_invalid = { .addr.v4.as_int = -1 };
-const ip_type ip_type_localhost = { .addr.v4 = {127, 0, 0, 1} };
+const ip_type ip_type_localhost = { .addr.v4.octet = {127, 0, 0, 1} };
 


### PR DESCRIPTION
It's been difficult getting the project's manually created 'configure' and 'Makefile' to play nice with Debian's auto build system when LDFLAGS are overridden with hardening options. It fails with a cryptic error message, so hopefully this would save others a few headaches.

Since we're trying to build a shared library, the -shared option should override all others.