### PR TITLE
Fix segmentation fault when chain_len option is missing '='.

### DIFF
--- a/src/libproxychains.c
+++ b/src/libproxychains.c
@@ -285,7 +285,7 @@ static void get_chain_data(proxy_data * pd, unsigned int *proxy_count, chain_typ
 					char *pc;
 					int len;
 					pc = strchr(buff, '=');
-					len = atoi(++pc);
+					len = pc ? atoi(++pc) : 0;
 					proxychains_max_chain = (len ? len : 1);
 				} else if(strstr(buff, "quiet_mode")) {
 					proxychains_quiet_mode = 1;


### PR DESCRIPTION
If chain_len is missing an equal sign in the config file, proxychains crashes. This fixes it.