### PR TITLE
@ravomavain's fix for random_chain always selecting the last proxy from the list on Mac OS X

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -464,7 +464,7 @@ static proxy_data *select_proxy(select_type how, proxy_data * pd, unsigned int p
 		case RANDOMLY:
 			do {
 				k++;
-				i = 0 + (unsigned int) (proxy_count * 1.0 * rand() / (RAND_MAX + 1.0));
+				i = rand() % proxy_count;
 			} while(pd[i].ps != PLAY_STATE && k < proxy_count * 100);
 			break;
 		case FIFOLY:


### PR DESCRIPTION
@ravomavain's fix for random_chain always selecting the last proxy from the list
on Mac OS X.

For more information see issue #75:

    https://github.com/rofl0r/proxychains-ng/issues/75#issuecomment-133454190

Tested on Mac and Linux and with these changes both now work as expected.