### PR TITLE
Fix spelling in log message: doesnt -> doesn't

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -269,7 +269,7 @@ static int tunnel_to(int sock, ip_type ip, unsigned short port, proxy_type pt, c
 		break;
 		case SOCKS4_TYPE:{
 			if(v6) {
-				proxychains_write_log(LOG_PREFIX "error: SOCKS4 doesnt support ipv6 addresses\n");
+				proxychains_write_log(LOG_PREFIX "error: SOCKS4 doesn't support ipv6 addresses\n");
 				goto err;
 			}
 			buff[0] = 4;	// socks version

--- a/src/main.c
+++ b/src/main.c
@@ -24,7 +24,7 @@
 static int usage(char **argv) {
 	printf("\nUsage:\t%s -q -f config_file program_name [arguments]\n"
 	       "\t-q makes proxychains quiet - this overrides the config setting\n"
-	       "\t-f allows to manually specify a configfile to use\n"
+	       "\t-f allows one to manually specify a configfile to use\n"
 	       "\tfor example : proxychains telnet somehost.com\n" "More help in README file\n\n", argv[0]);
 	return EXIT_FAILURE;
 }


### PR DESCRIPTION
Just a trivial spelling mistake that Lintian complains about.