### PR TITLE
update the proxychains.conf position in macOS Sierra

### DIFF
--- a/README
+++ b/README
@@ -174,6 +174,7 @@ proxychains looks for config file in following order:
 4)	$(sysconfdir)/proxychains.conf  **
 
 ** usually /etc/proxychains.conf
+** macOS Sierra /usr/local/etc/proxychains.conf
 
 Usage Example:
 


### PR DESCRIPTION
Seems the current README file has wrong info about the proxychains.conf position