### PR TITLE
revert patch

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -350,8 +350,8 @@ static int tunnel_to(int sock, ip_type ip, unsigned short port, proxy_type pt, c
 
 				if(2 != read_n_bytes(sock, in, 2))
 					goto err;
-				if(in[0] != 5 || in[1] != 0) {
-					if(in[0] != 5)
+				if(in[0] != 1 || in[1] != 0) {
+					if(in[0] != 1)
 						goto err;
 					else
 						return BLOCKED;


### PR DESCRIPTION
This patch actually breaks proxychains-ng for me:
```
$ ./proxychains4 wget -O- google.com
[proxychains] config file found: /home/user/.proxychains/proxychains.conf
[proxychains] preloading ./libproxychains4.so
[proxychains] DLL init: proxychains-ng 4.12-git-14-g06c20ed
--2018-03-05 22:16:43-- http://google.com/
Resolving google.com (google.com)... 224.0.0.1
Connecting to google.com (google.com)|224.0.0.1|:80... [proxychains] Strict chain ... 127.0.0.1:5555 ... google.com:80 <--socket error or timeout!
failed: Connection refused.
```