### PR TITLE
allocator_thread.c: set O_CLOEXEC/FD_CLOEXEC for pipes, fix Issue #273. 

### DIFF
--- a/configure
+++ b/configure
@@ -18,7 +18,7 @@ check_compile() {
 	printf "checking %s ... " "$1"
 	printf "$3" > "$tmpc"
 	local res=0
-	$CC $OUR_CPPFLAGS $CPPFLAGS $2 $CFLAGS -c "$tmpc" -o /dev/null >/dev/null 2>&1 \
+	$CC $OUR_CPPFLAGS $CPPFLAGS $2 $CFLAGS "$tmpc" -o /dev/null >/dev/null 2>&1 \
 	|| res=1
 	test x$res = x0 && \
 	{ printf "yes\n" ; test x"$2" = x || OUR_CPPFLAGS="$OUR_CPPFLAGS $2" ; } \

--- a/configure
+++ b/configure
@@ -152,6 +152,9 @@ issolaris() {
 check_compile 'whether we have GNU-style getservbyname_r()' "-DHAVE_GNU_GETSERVBYNAME_R" \
 '#define _GNU_SOURCE\n#include <netdb.h>\nint main() {\nstruct servent *se = 0;struct servent se_buf;char buf[1024];\ngetservbyname_r("foo", (void*) 0, &se_buf, buf, sizeof(buf), &se);\nreturn 0;}'
 
+check_compile 'whether we have pipe2() and O_CLOEXEC' "-DHAVE_PIPE2" \
+'#define _GNU_SOURCE\n#include <fcntl.h>\n#include <unistd.h>\nint main() {\nint pipefd[2];\npipe2(pipefd, O_CLOEXEC);\nreturn 0;}'
+
 check_define __APPLE__ && {
 	mac_detected=true
 	check_define __x86_64__ && mac_64=true

--- a/src/allocator_thread.c
+++ b/src/allocator_thread.c
@@ -309,7 +309,18 @@ size_t at_get_host_for_ip(ip_type4 ip, char* readbuf) {
 
 
 static void initpipe(int* fds) {
-	if(pipe(fds) == -1) {
+	int retval;
+
+#ifdef HAVE_PIPE2
+	retval = pipe2(fds, O_CLOEXEC);
+#else
+	retval = pipe(fds);
+	if(retval == 0) {
+		fcntl(fds[0], F_SETFD, FD_CLOEXEC);
+		fcntl(fds[1], F_SETFD, FD_CLOEXEC);
+	}
+#endif
+	if(retval == -1) {
 		perror("pipe");
 		exit(1);
 	}


### PR DESCRIPTION
```
In proxychains, we create pipes and use them internally.
If exec() is called by the program we run, the pipes opened
previously are never closed, causing a file descriptor leak
may eventually crash the program.

This commit calls fcntl() to set FD_CLOEXEC flags on pipes.
AFAIK there's no race condition on pipe creation, but we still
prefer to call the newer pipe2() with O_CLOEXEC if it's supported
by the system, due to its advantage of atomic operation, which
prevents potential race conditions in the future.

Signed-off-by: Tom Li <tomli@tomli.me>
```