### PR TITLE
get own_dir by using dladdr() instead of argv[0]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ $(LDSO_PATHNAME): $(LOBJS)
 		-shared -o $@ $(LOBJS) $(SOCKET_LIBS)
 
 $(ALL_TOOLS): $(OBJS)
-	$(CC) src/main.o src/common.o $(USER_LDFLAGS) -o $(PXCHAINS)
+	$(CC) src/main.o src/common.o $(USER_LDFLAGS) $(LIBDL) -o $(PXCHAINS)
 
 
 .PHONY: all clean install install-config install-libs install-tools

--- a/src/main.c
+++ b/src/main.c
@@ -19,6 +19,11 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
+#ifdef IS_MAC
+#define _DARWIN_C_SOURCE
+#endif
+#include <dlfcn.h>
+
 #include "common.h"
 
 static int usage(char **argv) {
@@ -111,7 +116,9 @@ int main(int argc, char *argv[]) {
 
 	// search DLL
 
-	set_own_dir(argv[0]);
+	Dl_info dli;
+	dladdr(own_dir, &dli);
+	set_own_dir(dli.dli_fname);
 
 	i = 0;
 

--- a/src/main.c
+++ b/src/main.c
@@ -49,7 +49,7 @@ static void set_own_dir(const char *argv0) {
 	size_t l = strlen(argv0);
 	while(l && argv0[l - 1] != '/')
 		l--;
-	if(l == 0)
+	if(l == 0 || l >= sizeof(own_dir))
 #ifdef SUPER_SECURE
 		memcpy(own_dir, "/dev/null/", 11);
 #else


### PR DESCRIPTION
This PR should fix bug #43  