### PR TITLE
support 'raw' proxy type

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -222,6 +222,10 @@ static int tunnel_to(int sock, ip_type ip, unsigned short port, proxy_type pt, c
 	int v6 = ip.is_v6;
 	
 	switch (pt) {
+		case RAW_TYPE: {
+			return SUCCESS;
+		}
+		break;
 		case HTTP_TYPE:{
 			if(!dns_len) {
 				if(!inet_ntop(v6?AF_INET6:AF_INET,ip.addr.v6,ip_buf,sizeof ip_buf)) {

--- a/src/core.h
+++ b/src/core.h
@@ -41,7 +41,8 @@ typedef enum {
 typedef enum {
 	HTTP_TYPE,
 	SOCKS4_TYPE,
-	SOCKS5_TYPE
+	SOCKS5_TYPE,
+	RAW_TYPE
 } proxy_type;
 
 typedef enum {

--- a/src/libproxychains.c
+++ b/src/libproxychains.c
@@ -354,6 +354,8 @@ inv_host:
 
 				if(!strcmp(type, "http")) {
 					pd[count].pt = HTTP_TYPE;
+				} else if(!strcmp(type, "raw")) {
+					pd[count].pt = RAW_TYPE;
 				} else if(!strcmp(type, "socks4")) {
 					pd[count].pt = SOCKS4_TYPE;
 				} else if(!strcmp(type, "socks5")) {

--- a/src/proxychains.conf
+++ b/src/proxychains.conf
@@ -145,7 +145,8 @@ tcp_connect_time_out 8000
 #	        http	192.168.39.93	8080	
 #		
 #
-#       proxy types: http, socks4, socks5
+#       proxy types: http, socks4, socks5, raw
+#         * raw: The traffic is simply forwarded to the proxy without modification.
 #        ( auth types supported: "basic"-http  "user/pass"-socks )
 #
 [ProxyList]


### PR DESCRIPTION
Hello!

We have a use case where we want to use proxychains with a proxy that does not support CONNECT (some kubernetes-ingress-nginx thigny).

This implementation covers our use case perfectly.

Sending the PR in case you find this useful or if you have feedback.

Thanks for maintaining proxychains :)

Cheers,