### PR TITLE
Remove trailing whitespace in proxychains.conf

### DIFF
--- a/src/proxychains.conf
+++ b/src/proxychains.conf
@@ -79,12 +79,12 @@ proxy_dns
 # we use the reserved 224.x.x.x range by default,
 # if the proxified app does a DNS request, we will return an IP from that range.
 # on further accesses to this ip we will send the saved DNS name to the proxy.
-# in case some control-freak app checks the returned ip, and denies to 
+# in case some control-freak app checks the returned ip, and denies to
 # connect, you can use another subnet, e.g. 10.x.x.x or 127.x.x.x.
 # of course you should make sure that the proxified app does not need
-# *real* access to this subnet. 
+# *real* access to this subnet.
 # i.e. dont use the same subnet then in the localnet section
-#remote_dns_subnet 127 
+#remote_dns_subnet 127
 #remote_dns_subnet 10
 remote_dns_subnet 224
 
@@ -105,7 +105,7 @@ tcp_connect_time_out 8000
 
 ## RFC5735 Loopback address range
 ## if you enable this, you have to make sure remote_dns_subnet is not 127
-## you'll need to enable it if you want to use an application that 
+## you'll need to enable it if you want to use an application that
 ## connects to localhost.
 # localnet 127.0.0.0/255.0.0.0
 
@@ -142,8 +142,8 @@ tcp_connect_time_out 8000
 #            	socks5	192.168.67.78	1080	lamer	secret
 #		http	192.168.89.3	8080	justu	hidden
 #	 	socks4	192.168.1.49	1080
-#	        http	192.168.39.93	8080	
-#		
+#	        http	192.168.39.93	8080
+#
 #
 #       proxy types: http, socks4, socks5, raw
 #         * raw: The traffic is simply forwarded to the proxy without modification.
@@ -154,4 +154,3 @@ tcp_connect_time_out 8000
 # meanwile
 # defaults set to "tor"
 socks4 	127.0.0.1 9050
-


### PR DESCRIPTION
Remove trailing whitespace in the default configuration file.