### PR TITLE
add support for a fixed number of proxies that are *always* used

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -84,8 +84,7 @@ typedef struct {
 } proxy_data;
 
 int connect_proxy_chain (int sock, ip_type target_ip, unsigned short target_port,
-			 proxy_data * pd, unsigned int proxy_count, chain_type ct,
-			 unsigned int max_chain );
+			 proxy_data * pd, unsigned int proxy_count, chain_type ct );
 
 void proxychains_write_log(char *str, ...);
 
@@ -129,6 +128,9 @@ void proxy_freeaddrinfo(struct addrinfo *res);
 
 void core_initialize(void);
 void core_unload(void);
+
+extern unsigned int proxychains_max_chain;
+extern unsigned int proxychains_fixed_chain;
 
 #include "debug.h"
 

--- a/src/proxychains.conf
+++ b/src/proxychains.conf
@@ -45,6 +45,12 @@ strict_chain
 # Make sense only if random_chain or round_robin_chain
 #chain_len = 2
 
+# use this if you want to use e.g. random_chain but always have
+# e.g. tor as first proxy. in that case only chain_len - fixed_len proxies
+# will be used for random chain.
+# currently only implemented for dynamic_chain and random_chain.
+#fixed_len = 1
+
 # Quiet mode (no output from library)
 #quiet_mode
 


### PR DESCRIPTION
e.g. for having tor fixed as first proxy, then using the rest for
random selection.