### PR TITLE
macos: replace i386 with arm64e in fat binary option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,10 +92,10 @@ $(LDSO_PATHNAME): $(LOBJS)
 		-shared -o $@ $^ $(SOCKET_LIBS)
 
 $(PXCHAINS): $(OBJS)
-	$(CC) $^ $(USER_LDFLAGS) $(LIBDL) -o $@
+	$(CC) $^ $(LDFLAGS) $(USER_LDFLAGS) $(LIBDL) -o $@
 
 $(PXCHAINS_D): $(DOBJS)
-	$(CC) $^ $(USER_LDFLAGS) -o $@
+	$(CC) $^ $(LDFLAGS) $(USER_LDFLAGS) -o $@
 
 
 .PHONY: all clean install install-config install-libs install-tools

--- a/configure
+++ b/configure
@@ -71,7 +71,7 @@ usage() {
 	echo "--ignore-cve              default: no"
 	echo "	if set to yes ignores CVE-2015-3887 and makes it possible"
 	echo "	to preload from current dir (insecure)"
-	echo "--fat-binary : build for both i386 and x86_64 architectures on 64-bit Macs"
+	echo "--fat-binary : build for both arm64e and x86_64 architectures on 64-bit Macs"
 	echo "--help : show this text"
 	exit 1
 }
@@ -225,9 +225,9 @@ if ismac ; then
 	echo LDSO_SUFFIX=dylib>>config.mak
 	echo MAC_CFLAGS+=-DIS_MAC=1>>config.mak
 	if ismac64 && [ "$fat_binary" = 1 ] ; then
-		echo "Configuring a fat binary for i386 and x86_64"
-		echo MAC_CFLAGS+=-arch i386 -arch x86_64>>config.mak
-		echo LDFLAGS+=-arch i386 -arch x86_64>>config.mak
+		echo "Configuring a fat binary for arm64e and x86_64"
+		echo MAC_CFLAGS+=-arch arm64e -arch x86_64>>config.mak
+		echo LDFLAGS+=-arch arm64e -arch x86_64>>config.mak
 	fi
 elif isbsd ; then
 	echo LIBDL=>>config.mak


### PR DESCRIPTION
Since macOS Big Sur, system libraries and executables are universal binaries of x86_64 and arm64e, and to inject dynamic libraries into universal executables, libproxychains4.dylib should also be a universal binary.
I'm not sure if it is okay to just drop i386 in LDFLAGS so open as draft