### PR TITLE
configure: fix check_link_silent test

### DIFF
--- a/configure
+++ b/configure
@@ -19,11 +19,12 @@ check_compile() {
 	printf "checking %s ... " "$1"
 	printf "$3" > "$tmpc"
 	local res=0
-	$CC $OUR_CPPFLAGS $CPPFLAGS $2 $CFLAGS "$tmpc" -o /dev/null >/dev/null 2>&1 \
+	$CC $OUR_CPPFLAGS $CPPFLAGS $2 $CFLAGS "$tmpc" -o "$tmpc".out >/dev/null 2>&1 \
 	|| res=1
 	test x$res = x0 && \
 	{ printf "yes\n" ; test x"$2" = x || OUR_CPPFLAGS="$OUR_CPPFLAGS $2" ; } \
 	|| printf "no\n"
+	rm -f "$tmpc".out
 	return $res
 }
 
@@ -49,7 +50,8 @@ check_compile_run() {
 
 check_link_silent() {
 	printf "$2" > "$tmpc"
-	$CC $OUR_CPPFLAGS $CPPFLAGS $1 $CFLAGS "$tmpc" -o /dev/null >/dev/null 2>&1
+	$CC $OUR_CPPFLAGS $CPPFLAGS $1 $CFLAGS "$tmpc" -o "$tmpc".out  >/dev/null 2>&1
+	rm -f "$tmpc".out
 }
 
 check_link() {


### PR DESCRIPTION
Replace `-o /dev/null` by `-o "$tmpc".out` in `check_link_silent` otherwise test will fail with some bugged binutils (https://sourceware.org/bugzilla/show_bug.cgi?id=19526) since version 4.13 and https://github.com/rofl0r/proxychains-ng/commit/35a674bdbc294730429a1007c9e7ce01e65b49b5:

```
checking what's the option to use in linker to set library name ...
cannot find an option to set library name
package/pkg-generic.mk:249: recipe for target '/home/buildroot/autobuild/instance-2/output-1/build/proxychains-ng-4.14/.stamp_configured' failed
```

Fixes:
 - http://autobuild.buildroot.org/results/9320d9b2c69882e23bbe7b30057eb8bee0c9d2e5

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>