### PR TITLE
proxy_getaddrinfo(): Fill in ai_socktype if requested

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -1018,6 +1018,8 @@ int proxy_getaddrinfo(const char *node, const char *service, const struct addrin
 		p->ai_socktype = hints->ai_socktype;
 		p->ai_flags = hints->ai_flags;
 		p->ai_protocol = hints->ai_protocol;
+		if(!p->ai_socktype && p->ai_protocol == IPPROTO_TCP)
+			p->ai_socktype = SOCK_STREAM;
 	} else {
 #ifndef AI_V4MAPPED
 #define AI_V4MAPPED 0

--- a/src/proxychains.conf
+++ b/src/proxychains.conf
@@ -53,9 +53,9 @@ strict_chain
 
 # method 1. this uses the proxychains4 style method to do remote dns:
 # a thread is spawned that serves DNS requests and hands down an ip
-# assigned from an internal list (via remote_dns_subset).
+# assigned from an internal list (via remote_dns_subnet).
 # this is the easiest (setup-wise) and fastest method, however on
-# systems with buggy libcs and very complex software like webbrosers
+# systems with buggy libcs and very complex software like webbrowsers
 # this might not work and/or cause crashes.
 proxy_dns
 


### PR DESCRIPTION
If the application specifies a protocol but not a socket type, normally `getaddrinfo` will select a corresponding protocol.

Mimic this behavior in our implementation of the function as well.

Fixes proxifying pssh.

- Fixes #426