### PR TITLE
add configure check for non-POSIX compliant getnameinfo signature

### DIFF
--- a/configure
+++ b/configure
@@ -175,6 +175,20 @@ ishaiku() {
 
 check_compile 'whether C compiler works' '' 'int main() {return 0;}' || fail 'error: install a C compiler and library'
 
+if ! check_compile 'whether getnameinfo() servlen argument is POSIX compliant (socklen_t)' "-DGN_SERVLEN_T=socklen_t -DGN_FLAGS_T=int" \
+'#define _GNU_SOURCE\n#include <netdb.h>\nint getnameinfo(const struct sockaddr *, socklen_t, char *, socklen_t, char *, socklen_t, int);int main() {\nreturn 0;}' ; then
+
+# GLIBC < 2.14
+ if ! check_compile 'whether getnameinfo() flags argument is unsigned' "-DGN_SERVLEN_T=socklen_t -DGN_FLAGS_T=unsigned" \
+  '#define _GNU_SOURCE\n#include <netdb.h>\nint getnameinfo(const struct sockaddr *, socklen_t, char *, socklen_t, char *, socklen_t, unsigned);int main() {\nreturn 0;}' ; then
+# OpenBSD
+  if ! check_compile 'whether getnameinfo() servlen argument is size_t' "-DGN_SERVLEN_T=size_t -DGN_FLAGS_T=int" \
+   '#define _GNU_SOURCE\n#include <netdb.h>\nint getnameinfo(const struct sockaddr *, socklen_t, char *, socklen_t, char *, size_t, int);int main() {\nreturn 0;}' ; then
+    fail "failed to detect getnameinfo signature"
+  fi
+ fi
+fi
+
 check_compile 'whether we have GNU-style getservbyname_r()' "-DHAVE_GNU_GETSERVBYNAME_R" \
 '#define _GNU_SOURCE\n#include <netdb.h>\nint main() {\nstruct servent *se = 0;struct servent se_buf;char buf[1024];\ngetservbyname_r("foo", (void*) 0, &se_buf, buf, sizeof(buf), &se);\nreturn 0;}'
 

--- a/configure
+++ b/configure
@@ -175,16 +175,20 @@ ishaiku() {
 
 check_compile 'whether C compiler works' '' 'int main() {return 0;}' || fail 'error: install a C compiler and library'
 
-if ! check_compile 'whether getnameinfo() servlen argument is POSIX compliant (socklen_t)' "-DGN_SERVLEN_T=socklen_t -DGN_FLAGS_T=int" \
+if ! check_compile 'whether getnameinfo() servlen argument is POSIX compliant (socklen_t)' "-DGN_NODELEN_T=socklen_t -DGN_SERVLEN_T=socklen_t -DGN_FLAGS_T=int" \
 '#define _GNU_SOURCE\n#include <netdb.h>\nint getnameinfo(const struct sockaddr *, socklen_t, char *, socklen_t, char *, socklen_t, int);int main() {\nreturn 0;}' ; then
 
 # GLIBC < 2.14
- if ! check_compile 'whether getnameinfo() flags argument is unsigned' "-DGN_SERVLEN_T=socklen_t -DGN_FLAGS_T=unsigned" \
+ if ! check_compile 'whether getnameinfo() flags argument is unsigned' "-DGN_NODELEN_T=socklen_t -DGN_SERVLEN_T=socklen_t -DGN_FLAGS_T=unsigned" \
   '#define _GNU_SOURCE\n#include <netdb.h>\nint getnameinfo(const struct sockaddr *, socklen_t, char *, socklen_t, char *, socklen_t, unsigned);int main() {\nreturn 0;}' ; then
 # OpenBSD
-  if ! check_compile 'whether getnameinfo() servlen argument is size_t' "-DGN_SERVLEN_T=size_t -DGN_FLAGS_T=int" \
+  if ! check_compile 'whether getnameinfo() servlen argument is size_t' "-DGN_NODELEN_T=socklen_t -DGN_SERVLEN_T=size_t -DGN_FLAGS_T=int" \
    '#define _GNU_SOURCE\n#include <netdb.h>\nint getnameinfo(const struct sockaddr *, socklen_t, char *, socklen_t, char *, size_t, int);int main() {\nreturn 0;}' ; then
-    fail "failed to detect getnameinfo signature"
+# FreeBSD
+   if ! check_compile 'whether getnameinfo() servlen and nodelen argument is size_t' "-DGN_NODELEN_T=size_t -DGN_SERVLEN_T=size_t -DGN_FLAGS_T=int" \
+    '#define _GNU_SOURCE\n#include <netdb.h>\nint getnameinfo(const struct sockaddr *, socklen_t, char *, size_t, char *, size_t, int);int main() {\nreturn 0;}' ; then
+     fail "failed to detect getnameinfo signature"
+   fi
   fi
  fi
 fi

--- a/src/core.h
+++ b/src/core.h
@@ -109,7 +109,7 @@ typedef int (*getaddrinfo_t)(const char *, const char *, const struct addrinfo *
 			     struct addrinfo **);
 
 typedef int (*getnameinfo_t) (const struct sockaddr *, socklen_t, char *, 
-			      socklen_t, char *, socklen_t, int);
+			      socklen_t, char *, GN_SERVLEN_T, GN_FLAGS_T);
 
 typedef ssize_t (*sendto_t) (int sockfd, const void *buf, size_t len, int flags,
 			     const struct sockaddr *dest_addr, socklen_t addrlen);

--- a/src/core.h
+++ b/src/core.h
@@ -109,7 +109,7 @@ typedef int (*getaddrinfo_t)(const char *, const char *, const struct addrinfo *
 			     struct addrinfo **);
 
 typedef int (*getnameinfo_t) (const struct sockaddr *, socklen_t, char *, 
-			      socklen_t, char *, GN_SERVLEN_T, GN_FLAGS_T);
+			      GN_NODELEN_T, char *, GN_SERVLEN_T, GN_FLAGS_T);
 
 typedef ssize_t (*sendto_t) (int sockfd, const void *buf, size_t len, int flags,
 			     const struct sockaddr *dest_addr, socklen_t addrlen);

--- a/src/libproxychains.c
+++ b/src/libproxychains.c
@@ -730,7 +730,7 @@ HOOKFUNC(void, freeaddrinfo, struct addrinfo *res) {
 
 HOOKFUNC(int, getnameinfo, const struct sockaddr *sa, socklen_t salen,
 	           char *host, socklen_t hostlen, char *serv,
-	           socklen_t servlen, int flags)
+	           GN_SERVLEN_T servlen, GN_FLAGS_T flags)
 {
 	INIT();
 	PFUNC();

--- a/src/libproxychains.c
+++ b/src/libproxychains.c
@@ -729,7 +729,7 @@ HOOKFUNC(void, freeaddrinfo, struct addrinfo *res) {
 }
 
 HOOKFUNC(int, getnameinfo, const struct sockaddr *sa, socklen_t salen,
-	           char *host, socklen_t hostlen, char *serv,
+	           char *host, GN_NODELEN_T hostlen, char *serv,
 	           GN_SERVLEN_T servlen, GN_FLAGS_T flags)
 {
 	INIT();


### PR DESCRIPTION
- glibc < 2.14 uses "unsigned" instead of "int" for flags
- openbsd uses "size_t" instead of socklen_t for servlen, while using
  socklen_t for all other arguments still.

closes #430