### PR TITLE
Preserve dnat mapping when used with localnet.

### DIFF
--- a/src/libproxychains.c
+++ b/src/libproxychains.c
@@ -743,6 +743,10 @@ HOOKFUNC(int, connect, int sock, const struct sockaddr *addr, unsigned int len) 
 			if((p_addr_in->s_addr ^ localnet_addr[i].in_addr.s_addr) & localnet_addr[i].in_mask.s_addr)
 				continue;
 		}
+		if (!v6 && dnat) {
+			memcpy(&((struct sockaddr_in *) addr)->sin_addr, p_addr_in, sizeof(*p_addr_in));
+			((struct sockaddr_in *) addr)->sin_port = htons(port);
+		}
 		PDEBUG("accessing localnet using true_connect\n");
 		return true_connect(sock, addr, len);
 	}


### PR DESCRIPTION
This allows using proxychains as a means of just changing the destination IP and port of network traffic similar to iptables DNAT without the need for root permissions.

Example usage:

localnet 127.0.0.0/8
dnat 1.1.1.1:1234 127.0.0.1:8123

This will redirect traffic to 1.1.1.1 on port 1234 to 127.0.0.1:8123.