### PR TITLE
Dl_info is undeclared with uclibc-ng without __USE_GNU

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -19,6 +19,9 @@
 #ifdef IS_MAC
 #define _DARWIN_C_SOURCE
 #endif
+#ifdef __UCLIBC__
+#define __USE_GNU
+#endif
 #include <dlfcn.h>
 
 #include "common.h"


### PR DESCRIPTION
 - like https://github.com/rofl0r/proxychains-ng/issues/338
 - refs https://github.com/wbx-github/uclibc-ng/blob/v1.0.44/include/dlfcn.h#L90
 - used https://github.com/Freetz-NG/freetz-ng/commit/3336514d8c5a49dd346432b68c0611be2ff37ea1