### PR TITLE
OpenBSD no longer uses ' ' as LD_PRELOAD separator, switch to ':'

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -135,16 +135,20 @@ int main(int argc, char *argv[]) {
 	if(!quiet)
 		fprintf(stderr, LOG_PREFIX "preloading %s/%s\n", prefix, dll_name);
 
+#if defined(IS_MAC) || defined(IS_OPENBSD)
+#define LD_PRELOAD_SEP ":"
+#else
+/* Dynlinkers for Linux and most BSDs seem to support space
+   as LD_PRELOAD separator, with colon added only recently.
+   We use the old syntax for maximum compat */
+#define LD_PRELOAD_SEP " "
+#endif
+
 #ifdef IS_MAC
 	putenv("DYLD_FORCE_FLAT_NAMESPACE=1");
 #define LD_PRELOAD_ENV "DYLD_INSERT_LIBRARIES"
-#define LD_PRELOAD_SEP ":"
 #else
 #define LD_PRELOAD_ENV "LD_PRELOAD"
-/* all historic implementations of BSD and linux dynlinkers seem to support
-   space as LD_PRELOAD separator, with colon added only recently.
-   we use the old syntax for maximum compat */
-#define LD_PRELOAD_SEP " "
 #endif
 	char *old_val = getenv(LD_PRELOAD_ENV);
 	snprintf(buf, sizeof(buf), LD_PRELOAD_ENV "=%s/%s%s%s",


### PR DESCRIPTION
Screenshot showing that space isn't a separator but colon is on OpenBSD:
![ld so example](https://github.com/rofl0r/proxychains-ng/assets/25590950/680ad03c-fd37-41ef-97d1-d97fb8bc21b8)

Here's a proxychains-ng 4.15 from the package repositories exhibiting the bug, and the current master with this commit working:
![test](https://github.com/rofl0r/proxychains-ng/assets/25590950/9785a10e-966b-43ef-af5e-670990e56d70)