### PR TITLE
integrated quick-sort into `intsort` function

### DIFF
--- a/src/libproxychains.c
+++ b/src/libproxychains.c
@@ -603,15 +603,53 @@ static int is_v4inv6(const struct in6_addr *a) {
 	return !memcmp(a->s6_addr, "\0\0\0\0\0\0\0\0\0\0\xff\xff", 12);
 }
 
+// quick-sort for huge arrays -- in case they're ever needed
+#define XOR_SWAP(a, b) \
+    do { \
+        (a) ^= (b); \
+        (b) ^= (a); \
+        (a) ^= (b); \
+    } while (0)
+
+static int partition(int *arr, int low, int high) {
+	int pivot_idx, j, pivot, i = low - 1;
+	for (j = low, pivot = arr[high]; j < high; ++j) {
+		if (arr[j] < pivot) {
+			++i;
+			XOR_SWAP(arr[i], arr[j]);
+		}
+	}
+
+	pivot_idx = i + 1;
+	XOR_SWAP(arr[high], arr[pivot_idx]);
+	return pivot_idx;
+}
+
+static void quick_sort(int *arr, int low, int high) {
+	if (low >= high) {
+		return;
+	}
+
+	int pivot_idx = partition(arr, low, high);
+	quick_sort(arr, low, pivot_idx - 1);
+	quick_sort(arr, pivot_idx + 1, high);
+}
+
+static void selection_sort(int *a, int n) {
+	int i, j;
+	for(i = 0; i < n; ++i) {
+		for(j = i + 1; j < n; ++j) {
+			if(a[j] < a[i]) XOR_SWAP(a[i], a[j]);			
+		}
+	}
+}
+
 static void intsort(int *a, int n) {
-	int i, j, s;
-	for(i=0; i<n; ++i)
-		for(j=i+1; j<n; ++j)
-			if(a[j] < a[i]) {
-				s = a[i];
-				a[i] = a[j];
-				a[j] = s;
-			}
+	if (n <= 25) {
+		selection_sort(a, n);
+		return;
+	}
+	quick_sort(a, 0, n - 1);
 }
 
 /* Warning: Linux manual says the third arg is `unsigned int`, but unistd.h says `int`. */


### PR DESCRIPTION
## Description

This pull request introduces a hybrid sorting approach within the `intsort` function, combining both Selection Sort and Quick Sort algorithms. For small datasets (less than or equal to `25` elements), Selection Sort is utilized for its simplicity and efficiency. Conversely, for larger datasets, Quick Sort is employed to leverage its superior performance characteristics in case it's ever needed in future code commits.

## Reason:

- Optimal Performance: By utilizing Selection Sort for small datasets and Quick Sort for larger datasets, the `intsort` function achieves optimal performance across a wide range of input sizes. Selection Sort's efficiency for small datasets ensures quick sorting without overhead, while Quick Sort's superior performance scales efficiently for larger datasets.
- Scalability and Efficiency: The hybrid approach enhances the scalability and efficiency of the sorting function. It adapts dynamically to the size of the dataset, ensuring efficient sorting regardless of input size.

@rofl0r , Lemme know what you think about it?