### PR TITLE
Check if binary has capabilities set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ GENH = src/version.h
 
 CFLAGS  += -Wall -O0 -g -std=c99 -D_GNU_SOURCE -pipe
 NO_AS_NEEDED = -Wl,--no-as-needed
-LDFLAGS = -fPIC $(NO_AS_NEEDED) $(LIBDL) $(PTHREAD)
+LDFLAGS = -fPIC $(NO_AS_NEEDED) $(LIBDL) $(LIBCAP) $(PTHREAD)
 INC     = 
 PIC     = -fPIC
 AR      = $(CROSS_COMPILE)ar
@@ -97,7 +97,7 @@ $(LDSO_PATHNAME): $(LOBJS)
 		$(USER_LDFLAGS) -shared -o $@ $^ $(SOCKET_LIBS)
 
 $(PXCHAINS): $(OBJS)
-	$(CC) $^ $(FAT_BIN_LDFLAGS) $(USER_LDFLAGS) $(LIBDL) -o $@
+	$(CC) $^ $(FAT_BIN_LDFLAGS) $(USER_LDFLAGS) $(LIBDL) $(LIBCAP) -o $@
 
 $(PXCHAINS_D): $(DOBJS)
 	$(CC) $^ $(FAT_BIN_LDFLAGS) $(USER_LDFLAGS) -o $@

--- a/configure
+++ b/configure
@@ -260,6 +260,11 @@ if check_link "checking whether we can use -ldl" "-ldl" \
 echo "LIBDL = -ldl" >> config.mak
 fi
 
+if check_link "checking whether we can use -lcap" "-lcap" \
+"int main(){return 0;}" ; then
+echo "LIBCAP = -lcap" >> config.mak
+fi
+
 if check_link "checking whether we can use -lpthread" "-lpthread" \
 "int main(){return 0;}" ; then
 echo "PTHREAD = -lpthread" >> config.mak


### PR DESCRIPTION
Spend ages trying to figure out why `proxychains python ...` didn't work, turns out I had given `python` the `cap_net_bind_service` capability (useful, but breaks proxychains due to LD_PRELOAD no longer working [1])

This hopefully fixes a bunch of hard to debug issues ([like here](https://github.com/rofl0r/proxychains-ng/issues/498#issuecomment-1619625621)). Could be extended to check for suid binaries, etc 

[1] <https://stackoverflow.com/questions/18058426/does-using-linux-capabilities-disable-ld-preload>