### PR TITLE
Make `proxychains-ng` XDG-compliant for user config lookup

### DIFF
--- a/README
+++ b/README
@@ -210,12 +210,15 @@ Some cool features:
 Configuration:
 --------------
 
-proxychains looks for config file in following order:
-1)	file listed in environment variable PROXYCHAINS_CONF_FILE or
-	provided as a -f argument to proxychains script or binary.
-2)	./proxychains.conf
-3)	$(HOME)/.proxychains/proxychains.conf
-4)	$(sysconfdir)/proxychains.conf  **
+ProxyChains looks for the configuration file in the following order:
+
+1) The path specified via the `PROXYCHAINS_CONF_FILE` environment variable,  
+   or provided with the `-f` argument to the proxychains script or binary.
+2) `$XDG_CONFIG_HOME/proxychains/proxychains.conf`  
+   If `XDG_CONFIG_HOME` is not set, fallback to:  
+   `$HOME/.config/proxychains/proxychains.conf`
+3) (Haiku only) `$HOME/config/settings/proxychains.conf`
+4) `$(sysconfdir)/proxychains.conf`  
 
 ** usually /etc/proxychains.conf
 


### PR DESCRIPTION
Hi there,

While managing a shared Debian server, I used to populate basic configuration files under `/etc/skel` for new users. During this process, I noticed that `proxychains-ng` does not follow the XDG Base Directory Specification.

This little PR adds support for `$XDG_CONFIG_HOME` and `$HOME/.config/` as preferred user config locations, while preserving the Haiku-specific fallback in `~/config/settings/`. Legacy system fallbacks (`/etc`, `SYSCONFDIR`) are untouched.

Thanks for maintaining this tool!

Warm regards,
