### PR TITLE
Fix warning

### DIFF
--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -5,6 +5,7 @@
 
 */
 
+#undef _GNU_SOURCE
 #define _GNU_SOURCE
 #include <unistd.h>
 #define _POSIX_C_SOURCE 200809L


### PR DESCRIPTION
Fxes a _GNU_SOURCE redefinition in daemon.c using `#undef` just like in all the other files

```
src/daemon/daemon.c:8:9: warning: ‘_GNU_SOURCE’ redefined
    8 | #define _GNU_SOURCE
      |         ^~~~~~~~~~~
```